### PR TITLE
Refactor: updatePhoneBook sql 쿼리 최적화 및 test환경 분리

### DIFF
--- a/curtaincall/src/main/java/com/example/curtaincall/global/aop/TimeTrace.java
+++ b/curtaincall/src/main/java/com/example/curtaincall/global/aop/TimeTrace.java
@@ -1,0 +1,14 @@
+package com.example.curtaincall.global.aop;
+
+import lombok.extern.log4j.Log4j;
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TimeTrace {
+}

--- a/curtaincall/src/main/java/com/example/curtaincall/global/aop/TimeTraceAspect.java
+++ b/curtaincall/src/main/java/com/example/curtaincall/global/aop/TimeTraceAspect.java
@@ -1,0 +1,33 @@
+package com.example.curtaincall.global.aop;
+
+import lombok.extern.log4j.Log4j;
+import lombok.extern.log4j.Log4j2;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+
+@Log4j2
+@Component
+@Aspect
+public class TimeTraceAspect {
+    @Pointcut("@annotation(com.example.curtaincall.global.aop.TimeTrace)")
+    private void timeTracePointcut(){
+    }
+    @Around("timeTracePointcut()")
+    public Object traceTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        StopWatch stopWatch = new StopWatch();
+        try {
+            stopWatch.start();
+            return joinPoint.proceed(); // 실제 타겟 호출
+        } finally {
+            stopWatch.stop();
+            log.debug("{} - Total time = {}s",
+                    joinPoint.getSignature().toShortString(),
+                    stopWatch.getTotalTimeSeconds());
+        }
+    }
+
+}

--- a/curtaincall/src/main/java/com/example/curtaincall/repository/PhoneBookRepository.java
+++ b/curtaincall/src/main/java/com/example/curtaincall/repository/PhoneBookRepository.java
@@ -2,7 +2,10 @@ package com.example.curtaincall.repository;
 
 import com.example.curtaincall.domain.PhoneBook;
 import com.example.curtaincall.domain.User;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,6 +13,21 @@ import java.util.Optional;
 public interface PhoneBookRepository extends JpaRepository<PhoneBook,Long> {
     //    @Override
     List<PhoneBook> findByUser(User user);
+    @Query("select p from PhoneBook p where p.phoneNumber = :phoneNumber and p.user.id = :userId")
+    Optional<List<PhoneBook>> findByPhoneNumberAndUserId(@Param("phoneNumber") String phoneNumber,
+                                                         @Param("userId") Long userId);
+
+    @Modifying
+    @Query("update PhoneBook p " +
+            "set p.isCurtainCallOnAndOff = :isCurtaincall, " +
+            "p.nickName = :nickName, " +
+            "p.phoneNumber = :phoneBookNumber " +
+            "where p.phoneNumber = :phoneNumber and p.user.id = :userId")
+    void updateByPhoneNumberAndUserId(@Param("isCurtaincall") boolean isCurtaincall,
+                                      @Param("nickName") String nickName,
+                                      @Param("phoneBookNumber") String phoneBookNumber,
+                                      @Param("phoneNumber") String phoneNumber,
+                                      @Param("userId") Long userId);
     Optional<List<PhoneBook>> findByPhoneNumberAndUser(String phoneNumber, User user);
     void deleteByPhoneNumberAndUser(String phoneNumber,User user);
 }

--- a/curtaincall/src/main/java/com/example/curtaincall/service/PhoneBookService.java
+++ b/curtaincall/src/main/java/com/example/curtaincall/service/PhoneBookService.java
@@ -30,12 +30,11 @@ public class PhoneBookService {
                 .collect(Collectors.toList());
         phoneBookRepository.saveAll(phoneBooks);
     }
-    public void update(Map<String, Contact> putRequestDTO,User user){
+    public void update(Map<String, Contact> putRequestDTO,Long userId){
         for (String phoneNumber : putRequestDTO.keySet()) {
-            List<PhoneBook> phoneBooks = phoneBookRepository.findByPhoneNumberAndUser(phoneNumber, user)
-                    .orElseThrow(PhoneBookNotfoundException::new);
-            updatePhoneBookDAO(putRequestDTO, phoneNumber, phoneBooks);
-            phoneBookRepository.saveAll(phoneBooks);
+            Contact contact = putRequestDTO.get(phoneNumber);
+            phoneBookRepository.updateByPhoneNumberAndUserId(contact.getIsCurtainCallOnAndOff(),
+                    contact.getName(),contact.getPhoneNumber(),phoneNumber,userId);
         }
     }
 
@@ -85,7 +84,7 @@ public class PhoneBookService {
         contactMap.put(user.getPhoneNumber(), contacts);
         return ResponsePhoneBookDTO.builder().response(contactMap).build();
     }
-    private void updatePhoneBookDAO(Map<String, Contact> putRequestDTO, String phoneNumber, List<PhoneBook> phoneBooks) {
+    public void updatePhoneBookDAO(Map<String, Contact> putRequestDTO, String phoneNumber, List<PhoneBook> phoneBooks) {
         for (PhoneBook phoneBook : phoneBooks) {
             Contact contact = putRequestDTO.get(phoneNumber);
             phoneBook.setPhoneNumber(contact.getPhoneNumber());

--- a/curtaincall/src/main/java/com/example/curtaincall/service/UserService.java
+++ b/curtaincall/src/main/java/com/example/curtaincall/service/UserService.java
@@ -4,6 +4,7 @@ import com.example.curtaincall.dto.request.RequestRemovedNumberInPhoneBookDTO;
 import com.example.curtaincall.dto.request.RequestUserDTO;
 import com.example.curtaincall.dto.response.ResponsePhoneBookDTO;
 import com.example.curtaincall.dto.response.ResponseUserDTO;
+import com.example.curtaincall.global.aop.TimeTrace;
 import com.example.curtaincall.global.auth.CurtaincallUserInfo;
 import com.example.curtaincall.global.auth.jwt.JwtUtils;
 import com.example.curtaincall.global.exception.PhoneBookNotfoundException;
@@ -65,10 +66,9 @@ public class UserService {
         userRepository.save(user);
     }
 
+    @TimeTrace
     public void updatePhoneBook(Map<String, Contact> putRequestDTO,CustomUserDetails userDetails) {
-        User user = userRepository.findById(userDetails.getId()).orElseThrow(
-                UserNotfoundException::new);
-        phoneBookService.update(putRequestDTO,user);
+        phoneBookService.update(putRequestDTO,userDetails.getId());
     }
     public void deleteContactInPhoneNumber(CustomUserDetails userDetails,
                                            RequestRemovedNumberInPhoneBookDTO numbers){

--- a/curtaincall/src/main/resources/application-test.properties
+++ b/curtaincall/src/main/resources/application-test.properties
@@ -1,17 +1,15 @@
 spring.application.name=curtaincall
-
-
 spring.config.import=optional:application-secret.properties
-
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=jdbc:mysql://localhost:3306/curtaincall?serverTimezone=Asia/Seoul
+spring.datasource.url=jdbc:mysql://localhost:3306/curtaincall_test?serverTimezone=Asia/Seoul
 spring.datasource.username=root
 spring.datasource.password=mhg1018!
 
 spring.jpa.properties.hibernate.show_sql=false
 spring.jpa.properties.hibernate.format_sql=true
 
-spring.jpa.hibernate.ddl-auto=create
+#?? ??? ???? ??? ??? ??? ???
+spring.jpa.hibernate.ddl-auto=create-drop
 
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 spring.jpa.defer-datasource-initialization=true

--- a/curtaincall/src/main/resources/application-test.properties
+++ b/curtaincall/src/main/resources/application-test.properties
@@ -9,7 +9,7 @@ spring.jpa.properties.hibernate.show_sql=false
 spring.jpa.properties.hibernate.format_sql=true
 
 #?? ??? ???? ??? ??? ??? ???
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.ddl-auto=create
 
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 spring.jpa.defer-datasource-initialization=true
@@ -17,7 +17,14 @@ spring.jpa.defer-datasource-initialization=true
 # SQL ??? ??
 spring.sql.init.mode=always
 spring.sql.init.platform=mysql
+logging.
 
+logging.level.com.example.curtaincall=DEBUG
+
+##sql? ?????
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.hibernate.type.descriptor.sql=TRACE
+logging.level.org.hibernate.event.internal.DefaultFlushEntityEventListener=DEBUG
 
 
 spring.data.redis.host=localhost

--- a/curtaincall/src/test/java/com/example/curtaincall/service/UserServiceTest.java
+++ b/curtaincall/src/test/java/com/example/curtaincall/service/UserServiceTest.java
@@ -25,6 +25,7 @@ import java.util.*;
 
 
 @SpringBootTest
+@Transactional
 @ActiveProfiles("test")
 public class UserServiceTest {
     @Autowired
@@ -33,8 +34,6 @@ public class UserServiceTest {
     @Autowired
     private UserRepository userRepository;
     private CustomUserDetails userDetails1;
-    private CustomUserDetails userDetails2;
-    private CustomUserDetails userDetails3;
     @PostConstruct
     public void postConstruct(){
         User user1 = userRepository.findByPhoneNumber("01023326094")
@@ -49,14 +48,7 @@ public class UserServiceTest {
                 .nickName(user1.getNickName())
                 .build()
         );
-        userDetails2= new CustomUserDetails(CurtaincallUserInfo.builder()
-                .id(user2.getId())
-                .phoneNumber(user2.getPhoneNumber())
-                .isCurtaincall(user2.isCurtainCallOnAndOff())
-                .role(user2.getUserRole())
-                .nickName(user2.getNickName())
-                .build()
-        );
+
     }
 
 
@@ -72,7 +64,8 @@ public class UserServiceTest {
     }
     @DisplayName("user테이블에 이미 있는 번호를 저장 하면 예외가 발생한다.")
     @Test
-    public void saveByPhoneNumberInUserTable(){Assertions.assertThrows(UserAlreadyExistsException.class,()->userService.saveUser(RequestUserDTO.builder()
+    public void saveByPhoneNumberInUserTable(){
+        Assertions.assertThrows(UserAlreadyExistsException.class,()->userService.saveUser(RequestUserDTO.builder()
                 .phoneNumber("01023326094").nickName("nickname").isCurtainCall(true).build()));
     }
     @DisplayName("user테이블에 없는 번호를 저장 하면 잘 동작한다.")
@@ -82,7 +75,6 @@ public class UserServiceTest {
             .phoneNumber("01023326091").nickName("nickname").isCurtainCall(true).build()));
     }
 
-    @Transactional
     @DisplayName("01023326094 user의 번호들을 일괄 on으로 전환")
     @Test
     public void setAllOnCurtaincall(){
@@ -91,7 +83,7 @@ public class UserServiceTest {
         phoneBookByPhoneNumber.getResponse().get("01023326094").forEach(phoneBook->
                 Assertions.assertEquals(phoneBook.getIsCurtainCallOnAndOff(),true));
     }
-    @Transactional
+
     @DisplayName("01023326094 user의 번호들을 일괄 off로 전환")
     @Test
     public void setAllOffCurtaincall(){
@@ -99,7 +91,6 @@ public class UserServiceTest {
         phoneBookByPhoneNumber.getResponse().get("01023326094").forEach(phoneBook->
                 Assertions.assertEquals(phoneBook.getIsCurtainCallOnAndOff(),false));
     }
-    @Transactional
     @DisplayName("01023326094 user의 특정 번호들을  off로 전환")
     @Test
     public void setOffCurtaincall(){
@@ -111,7 +102,7 @@ public class UserServiceTest {
                 .findFirst();
         Assertions.assertEquals(first.get().getIsCurtainCallOnAndOff(),false);
     }
-    @Transactional
+
     @DisplayName("01023326094 user의 정보를 변경")
     @Test
     public void changeUser(){
@@ -120,7 +111,6 @@ public class UserServiceTest {
              .isCurtainCall(true).build(),userDetails1);
      Assertions.assertEquals("MunMun",userService.findUser(userDetails1).nickName());
     }
-    @Transactional
     @DisplayName("01023326094 phoneBook의 정보를 변경")
     @Test
     public void changePhoneBook(){
@@ -137,7 +127,6 @@ public class UserServiceTest {
                         "01044415552")).findFirst();
         Assertions.assertEquals(first.get().getName(),"조조");
     }
-    @Transactional
     @DisplayName("01023326094 user의 contact 변경")
     @Test
     public void deleteContact(){

--- a/curtaincall/src/test/java/com/example/curtaincall/service/UserServiceTest.java
+++ b/curtaincall/src/test/java/com/example/curtaincall/service/UserServiceTest.java
@@ -1,5 +1,6 @@
 package com.example.curtaincall.service;
 
+import com.example.curtaincall.domain.PhoneBook;
 import com.example.curtaincall.domain.User;
 import com.example.curtaincall.dto.Contact;
 import com.example.curtaincall.dto.request.RequestRemovedNumberInPhoneBookDTO;
@@ -7,6 +8,7 @@ import com.example.curtaincall.dto.request.RequestUserDTO;
 import com.example.curtaincall.dto.response.ResponsePhoneBookDTO;
 
 import com.example.curtaincall.global.SecretkeyManager;
+import com.example.curtaincall.global.aop.TimeTrace;
 import com.example.curtaincall.global.auth.CurtaincallUserInfo;
 import com.example.curtaincall.global.exception.UserAlreadyExistsException;
 import com.example.curtaincall.global.exception.UserNotfoundException;
@@ -48,7 +50,6 @@ public class UserServiceTest {
                 .nickName(user1.getNickName())
                 .build()
         );
-
     }
 
 
@@ -71,7 +72,7 @@ public class UserServiceTest {
     @DisplayName("user테이블에 없는 번호를 저장 하면 잘 동작한다.")
     @Test
     public void saveByPhoneNumberUserTable(){
-        Assertions.assertNotNull(UserAlreadyExistsException.class,()->userService.saveUser(RequestUserDTO.builder()
+        Assertions.assertNotNull(userService.saveUser(RequestUserDTO.builder()
             .phoneNumber("01023326091").nickName("nickname").isCurtainCall(true).build()));
     }
 
@@ -112,6 +113,7 @@ public class UserServiceTest {
      Assertions.assertEquals("MunMun",userService.findUser(userDetails1).nickName());
     }
     @DisplayName("01023326094 phoneBook의 정보를 변경")
+    @TimeTrace
     @Test
     public void changePhoneBook(){
         Map<String,Contact> maps=new HashMap<>();
@@ -121,6 +123,7 @@ public class UserServiceTest {
                 .isCurtainCallOnAndOff(true)
                 .build());
         userService.updatePhoneBook(maps,userDetails1);
+        System.out.println("!!!!!!!!!!!!!!!!!!!");
         Optional<Contact> first = userService.findPhoneBook(userDetails1).getResponse().
                 get("01023326094")
                 .stream().filter(contact -> Objects.equals(contact.getPhoneNumber(),


### PR DESCRIPTION
## 🔎 작업 내용

- **`updatePhoneBook` SQL 쿼리 최적화**
   - 기존의 프로세스는 다음과 같았습니다:
     1. `findUser`
     2. `findPhoneBook`
     3. `save`
   - 그러나 이미 `PhoneBook` 테이블 내에 `userId`가 외래키로 존재하므로, 위와 같은 복잡한 과정을 거칠 필요 없이 **JPQL**을 활용한 **직접적인 `UPDATE` 쿼리**를 수행.
   - 최적화 결과:
     - **수행 시간**: 0.029초 → **0.014초**로 절감 ⏱️
     - 코드의 **가독성 향상** 및 **성능 최적화** 💡

- **테스트 환경 데이터베이스 재설정**
   - 테스트 환경에서의 신뢰성을 높이기 위해 **새로운 테스트 전용 DB** 생성 및 설정.
   - 환경 분리를 통해 **개발 환경과 테스트 환경의 충돌 방지** 및 **테스트 자동화 기반 마련**.

<br/>

## 🔧 앞으로의 과제

- **다른 리포지토리 코드의 쿼리 최적화**
  - 기존 쿼리의 성능을 면밀히 분석하여, 필요 시 **JPQL** 및 **네이티브 쿼리**로 전환.
  - 불필요한 데이터 로딩 방지 및 **Lazy Loading 최적화**.
  - 데이터베이스 성능 모니터링을 통해 병목 현상 탐지 및 개선.
  
<br/>

## ➕ 이슈 링크

[[#54](https://github.com/Project-CurtainCall/backend/issues/54)](https://github.com/Project-CurtainCall/backend/issues/54)

<br/>